### PR TITLE
fix invalid memory accesses & crashes

### DIFF
--- a/filet.c
+++ b/filet.c
@@ -359,7 +359,7 @@ main(int argc, char **argv)
     bool show_hidden = false;
     bool fetch_dir   = true;
     size_t sel       = 0;
-    DIR *last_dir    = 0;
+    DIR *last_dir    = NULL;
     size_t n;
 
     for (;;) {

--- a/filet.c
+++ b/filet.c
@@ -154,10 +154,16 @@ read_dir(
     const char *path,
     struct direlement **ents,
     size_t *ents_size,
+    DIR **last_dir,
     bool show_hidden)
 {
     size_t n = 0;
-    DIR *dir = opendir(path);
+    DIR *dir;
+    if (*last_dir) {
+      closedir(*last_dir);
+    }
+    dir = opendir(path);
+    *last_dir = dir;
     if (dir) {
         struct dirent *ent;
         while ((ent = readdir(dir))) {
@@ -207,7 +213,6 @@ read_dir(
 
             ++n;
         }
-        closedir(dir);
         qsort(*ents, n, sizeof(**ents), direlemcmp);
     }
 
@@ -356,12 +361,14 @@ main(int argc, char **argv)
     bool show_hidden = false;
     bool fetch_dir   = true;
     size_t sel       = 0;
+    DIR *last_dir    = 0;
     size_t n;
 
     for (;;) {
         if (fetch_dir) {
             fetch_dir = false;
-            n         = read_dir(path, &ents, &ents_size, show_hidden);
+            n         = read_dir(path, &ents, &ents_size, &last_dir,
+                                 show_hidden);
         }
 
         redraw(ents, n, sel, path, user, hostname);

--- a/filet.c
+++ b/filet.c
@@ -170,7 +170,6 @@ read_dir(
             const char *name = ent->d_name;
             int fd           = dirfd(dir);
             struct stat sb;
-            struct direlement *cur;
 
             if (name[0] == '.' &&
                 (name[1] == '\0' || (name[1] == '.' && name[2] == '\0'))) {
@@ -196,18 +195,17 @@ read_dir(
                 *ents = tmp;
             }
 
-            cur = &(*ents)[n];
-            cur->d_name = ent->d_name;
+            (*ents)[n].d_name = ent->d_name;
 
             if (S_ISDIR(sb.st_mode)) {
-                cur->type = TYPE_DIR;
+                (*ents)[n].type = TYPE_DIR;
             } else if (S_ISLNK(sb.st_mode)) {
-                cur->type = TYPE_SYML;
+                (*ents)[n].type = TYPE_SYML;
             } else {
                 if (sb.st_mode & S_IXUSR) {
-                    cur->type = TYPE_EXEC;
+                    (*ents)[n].type = TYPE_EXEC;
                 } else {
-                    cur->type = TYPE_NORM;
+                    (*ents)[n].type = TYPE_NORM;
                 }
             }
 


### PR DESCRIPTION
read_dir reassigns a local copy of ents when it reallocs (same goes for size) but the actual ents pointer in main is not reassigned, therefore any directory big enough to cause reallocs crashes. my solution is to pass pointers to ents and ents_size

another problem is that once you closedir the memory allocation for stuff like d_name is gone so you're accessing freed memory and potentially garbage, this is fixed without allocating copies of the strings by keeping the dir open and closing it next time read_dir is called