### PR TITLE
Fix compiler warnings

### DIFF
--- a/filet.c
+++ b/filet.c
@@ -100,15 +100,15 @@ strnatcmp(const char *s1, const char *s2)
             return 1;
         }
 
-        if (!(isdigit(*s1) && isdigit(*s2))) {
+        if (!(isdigit((int)*s1) && isdigit((int)*s2))) {
             if (*s1 != *s2) {
                 return (int)*s1 - (int)*s2;
             }
             ++s1;
             ++s2;
         } else {
-            const char *lim1;
-            const char *lim2;
+            char *lim1;
+            char *lim2;
             unsigned long n1 = strtoul(s1, &lim1, 10);
             unsigned long n2 = strtoul(s2, &lim2, 10);
             if (n1 > n2) {


### PR DESCRIPTION
```
cc -std=c11 -Wall -Wextra -pedantic -D_XOPEN_SOURCE=700   filet.c   -o filet
filet.c: In function ‘strnatcmp’:
filet.c:112:44: warning: passing argument 2 of ‘strtoul’ from incompatible pointer type [-Wincompatible-pointer-types]
             unsigned long n1 = strtoul(s1, &lim1, 10);
                                            ^
In file included from filet.c:13:0:
/usr/include/stdlib.h:180:26: note: expected ‘char ** restrict’ but argument is of type ‘const char **’
 extern unsigned long int strtoul (const char *__restrict __nptr,
                          ^~~~~~~
filet.c:113:44: warning: passing argument 2 of ‘strtoul’ from incompatible pointer type [-Wincompatible-pointer-types]
             unsigned long n2 = strtoul(s2, &lim2, 10);
                                            ^
In file included from filet.c:13:0:
/usr/include/stdlib.h:180:26: note: expected ‘char ** restrict’ but argument is of type ‘const char **’
 extern unsigned long int strtoul (const char *__restrict __nptr,
                          ^~~~~~~
```
